### PR TITLE
Add ID-MSCMA module and integrate attention alignment loss

### DIFF
--- a/models/LQVG.py
+++ b/models/LQVG.py
@@ -18,6 +18,7 @@ from .matcher import build_matcher
 from .criterion import SetCriterion
 from .postprocessors import build_postprocessors
 from .dsgl import DSGL
+from .id_mscma import ID_MSCMA, FiLMLite, attention_alignment_loss
 
 from transformers import BertTokenizer, BertModel, RobertaModel, RobertaTokenizerFast
 
@@ -123,6 +124,17 @@ class LQVG(nn.Module):
         self.text_pos = PositionEmbeddingSine1D(hidden_dim, normalize=True)
         self.poolout_module = RobertaPoolout(d_model=hidden_dim)
         self.dsgl = DSGL(embed_dim=hidden_dim, heatmap_size=32)
+        self.id_mscma = ID_MSCMA(
+            d_model=hidden_dim,
+            n_heads=8,
+            n_levels=4,
+            n_points=4,
+            n_layers=2,
+            weight_sharing=True,
+        )
+        self.film2 = FiLMLite(d_text=hidden_dim, c_vis=hidden_dim, init_alpha=0.1)
+        self.film3 = FiLMLite(d_text=hidden_dim, c_vis=hidden_dim, init_alpha=0.1)
+        self.lambda_aal = 0.05
 
     def forward(self, samples: NestedTensor, captions, targets):
 
@@ -231,6 +243,49 @@ class LQVG(nn.Module):
         text_word_features = rearrange(text_word_features, 'l b c -> b l c')
         text_sentence_features = self.poolout_module(text_word_features)
 
+        feats = []
+        for src in srcs:
+            b_t, c, h, w = src.shape
+            feat_bt = rearrange(src, '(b t) c h w -> b t c h w', b=b, t=t)
+            feat_avg = feat_bt.mean(dim=1)
+            feats.append(feat_avg)
+
+        mscma_txt = text_word_features
+        mscma_vis = None
+        attn_last = None
+        aal_gt_mask = None
+        if feats:
+            t_global = text_sentence_features
+            if len(feats) > 1:
+                feats[1] = self.film2(feats[1], t_global)
+            if len(feats) > 2:
+                feats[2] = self.film3(feats[2], t_global)
+
+            spatial_shapes = torch.as_tensor(
+                [[feat.shape[-2], feat.shape[-1]] for feat in feats],
+                dtype=torch.long,
+                device=feats[0].device,
+            )
+            level_start_index = spatial_shapes.prod(1).cumsum(0)
+            level_start_index = torch.roll(level_start_index, 1, dims=0)
+            level_start_index[0] = 0
+            B, L, _ = text_word_features.shape
+            reference_points = torch.full(
+                (B, L, len(feats), 2), 0.5, device=feats[0].device
+            )
+
+            mscma_txt, mscma_vis, attn_last = self.id_mscma(
+                text_word_features,
+                feats,
+                spatial_shapes,
+                level_start_index,
+                reference_points,
+                vis_tokens=None,
+            )
+
+            if targets is not None and all('masks' in tgt for tgt in targets):
+                aal_gt_mask = self._build_aal_mask(targets, feats, t, feats[0].device)
+
         # Transformer
         query_embeds = self.query_embed.weight  # [num_queries, c]
         text_embed = repeat(text_sentence_features, 'b c -> b t q c', t=t, q=self.num_queries)
@@ -239,6 +294,13 @@ class LQVG(nn.Module):
 
 
         out = {}
+        out['mscma_txt'] = mscma_txt
+        if mscma_vis is not None:
+            out['mscma_vis'] = mscma_vis
+        if attn_last is not None:
+            out['mscma_attn'] = attn_last
+        if aal_gt_mask is not None:
+            out['aal_gt_mask'] = aal_gt_mask
         # prediction
         outputs_classes = []
         outputs_coords = []
@@ -286,6 +348,45 @@ class LQVG(nn.Module):
         # as a dict having both a Tensor and a list.
         return [{"pred_logits": a, "pred_boxes": b}
                 for a, b in zip(outputs_class[:-1], outputs_coord[:-1])]
+
+    def _build_aal_mask(self, targets, feats, num_frames, device):
+        spatial_shapes = [(feat.shape[-2], feat.shape[-1]) for feat in feats]
+        total_tokens = sum(h * w for h, w in spatial_shapes)
+        gt_mask = torch.zeros(len(targets), total_tokens, device=device, dtype=feats[0].dtype)
+
+        offset = 0
+        for h, w in spatial_shapes:
+            level_masks = []
+            for target in targets:
+                if 'masks' not in target:
+                    level_masks.append(torch.zeros(h * w, device=device))
+                    continue
+
+                tgt_masks = target['masks']
+                if tgt_masks.dim() == 4:
+                    tgt_masks = tgt_masks[:, 0]
+                tgt_masks = tgt_masks[:num_frames].to(device=device, dtype=torch.float32)
+                if tgt_masks.numel() == 0:
+                    level_masks.append(torch.zeros(h * w, device=device))
+                    continue
+
+                if 'valid' in target:
+                    valid = target['valid'][:tgt_masks.shape[0]].to(device).view(-1, 1, 1)
+                    tgt_masks = tgt_masks[:valid.shape[0]] * valid
+
+                union_mask = tgt_masks.max(dim=0).values if tgt_masks.dim() > 2 else tgt_masks
+                resized = F.interpolate(
+                    union_mask.unsqueeze(0).unsqueeze(0),
+                    size=(h, w),
+                    mode='bilinear',
+                    align_corners=False,
+                ).squeeze(0).squeeze(0)
+                level_masks.append(resized.flatten())
+
+            gt_mask[:, offset:offset + h * w] = torch.stack(level_masks, dim=0)
+            offset += h * w
+
+        return gt_mask.clamp(0, 1)
 
     def forward_text(self, captions, device):
         if isinstance(captions[0], str):
@@ -398,6 +499,7 @@ def build(args):
     weight_dict['loss_bbox'] = args.bbox_loss_coef
     weight_dict['loss_giou'] = args.giou_loss_coef
     weight_dict['loss_dsgl'] = 1.0
+    weight_dict['loss_aal'] = model.lambda_aal
     if args.masks:  # always true
         weight_dict['loss_mask'] = args.mask_loss_coef
         weight_dict['loss_dice'] = args.dice_loss_coef
@@ -408,7 +510,7 @@ def build(args):
             aux_weight_dict.update({k + f'_{i}': v for k, v in weight_dict.items()})
         weight_dict.update(aux_weight_dict)
 
-    losses = ['labels', 'boxes', 'dsgl']
+    losses = ['labels', 'boxes', 'dsgl', 'aal']
     if args.masks:
         losses += ['masks']
     criterion = SetCriterion(

--- a/models/criterion.py
+++ b/models/criterion.py
@@ -8,6 +8,7 @@ from util.misc import (NestedTensor, nested_tensor_from_tensor_list,
                        is_dist_avail_and_initialized, inverse_sigmoid)
 
 from .segmentation import (dice_loss, sigmoid_focal_loss)
+from .id_mscma import attention_alignment_loss
 
 from einops import rearrange
 
@@ -188,6 +189,16 @@ class SetCriterion(nn.Module):
         loss_dsgl = self.lambda_heatmap * heatmap_loss + self.lambda_iou * iou_loss
         return {'loss_dsgl': loss_dsgl}
 
+    def loss_aal(self, outputs, targets, indices, num_boxes):
+        if 'mscma_attn' not in outputs or 'aal_gt_mask' not in outputs:
+            device = next(iter(outputs.values())).device
+            return {'loss_aal': torch.zeros([], device=device)}
+
+        attn = outputs['mscma_attn']
+        gt_mask = outputs['aal_gt_mask']
+        loss = attention_alignment_loss(attn, gt_mask, reduction='mean')
+        return {'loss_aal': loss}
+
     def _get_src_permutation_idx(self, indices):
         # permute predictions following indices
         batch_idx = torch.cat([torch.full_like(src, i) for i, (src, _) in enumerate(indices)])
@@ -205,7 +216,8 @@ class SetCriterion(nn.Module):
             'labels': self.loss_labels,
             'boxes': self.loss_boxes,
             'masks': self.loss_masks,
-            'dsgl': self.loss_dsgl
+            'dsgl': self.loss_dsgl,
+            'aal': self.loss_aal
         }
         assert loss in loss_map, f'do you really want to compute {loss} loss?'
         return loss_map[loss](outputs, targets, indices, num_boxes, **kwargs)

--- a/models/id_mscma.py
+++ b/models/id_mscma.py
@@ -1,0 +1,165 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+try:
+    from models.ops.modules import MSDeformAttn
+except Exception:  # pragma: no cover - fallback if ops unavailable at import time
+    MSDeformAttn = None
+
+
+class FFN(nn.Module):
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(d_model, 4 * d_model),
+            nn.GELU(),
+            nn.Dropout(0.1),
+            nn.Linear(4 * d_model, d_model),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class FiLMLite(nn.Module):
+    def __init__(self, d_text: int, c_vis: int, init_alpha: float = 0.1) -> None:
+        super().__init__()
+        self.mlp = nn.Sequential(
+            nn.LayerNorm(d_text),
+            nn.Linear(d_text, 2 * c_vis),
+            nn.GELU(),
+            nn.Linear(2 * c_vis, 2 * c_vis),
+        )
+        self.alpha = nn.Parameter(torch.tensor(init_alpha))
+
+    def forward(self, v: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        gamma, beta = self.mlp(t).chunk(2, dim=-1)
+        gamma = gamma[..., None, None]
+        beta = beta[..., None, None]
+        return v * (1 + self.alpha * gamma) + self.alpha * beta
+
+
+class MSDeformAttnAdapter(nn.Module):
+    def __init__(self, d_model: int = 256, n_heads: int = 8, n_levels: int = 4, n_points: int = 4) -> None:
+        super().__init__()
+        if MSDeformAttn is None:
+            raise ImportError("MSDeformAttn not found.")
+        self.attn = MSDeformAttn(d_model, n_levels, n_heads, n_points)
+        self.q_proj = nn.Linear(d_model, d_model)
+        self.out_proj = nn.Linear(d_model, d_model)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        feats: list[torch.Tensor],
+        spatial_shapes: torch.Tensor,
+        level_start_index: torch.Tensor,
+        reference_points: torch.Tensor,
+    ) -> torch.Tensor:
+        q_proj = self.q_proj(q)
+        value = torch.cat([feat.flatten(2).transpose(1, 2) for feat in feats], dim=1)
+        out = self.attn(q_proj, reference_points, value, spatial_shapes, level_start_index, None)
+        return self.out_proj(out)
+
+
+class BiDirCMLayer(nn.Module):
+    def __init__(self, d_model: int = 256, n_heads: int = 8, n_levels: int = 4, n_points: int = 4) -> None:
+        super().__init__()
+        self.lvi = MSDeformAttnAdapter(d_model, n_heads, n_levels, n_points)
+        self.lvi_norm1 = nn.LayerNorm(d_model)
+        self.lvi_ffn = FFN(d_model)
+        self.lvi_norm2 = nn.LayerNorm(d_model)
+
+        self.vli_attn = nn.MultiheadAttention(d_model, n_heads, batch_first=True)
+        self.vli_norm1 = nn.LayerNorm(d_model)
+        self.vli_ffn = FFN(d_model)
+        self.vli_norm2 = nn.LayerNorm(d_model)
+
+    def forward(
+        self,
+        txt_tokens: torch.Tensor,
+        vis_tokens: torch.Tensor,
+        feats: list[torch.Tensor],
+        spatial_shapes: torch.Tensor,
+        level_start_index: torch.Tensor,
+        reference_points: torch.Tensor,
+        txt_pos: torch.Tensor | None = None,
+        vis_pos: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        txt_query = txt_tokens + (txt_pos if txt_pos is not None else 0)
+        txt_attn = self.lvi(txt_query, feats, spatial_shapes, level_start_index, reference_points)
+        txt_res = self.lvi_norm1(txt_tokens + txt_attn)
+        txt_res = self.lvi_norm2(txt_res + self.lvi_ffn(txt_res))
+
+        vis_query = vis_tokens + (vis_pos if vis_pos is not None else 0)
+        vis_key = txt_res + (txt_pos if txt_pos is not None else 0)
+        vis_out, attn_weights = self.vli_attn(vis_query, vis_key, vis_key, need_weights=True)
+        vis_res = self.vli_norm1(vis_tokens + vis_out)
+        vis_res = self.vli_norm2(vis_res + self.vli_ffn(vis_res))
+        return txt_res, vis_res, attn_weights
+
+
+class ID_MSCMA(nn.Module):
+    def __init__(
+        self,
+        d_model: int = 256,
+        n_heads: int = 8,
+        n_levels: int = 4,
+        n_points: int = 4,
+        n_layers: int = 2,
+        weight_sharing: bool = True,
+    ) -> None:
+        super().__init__()
+        self.n_layers = n_layers
+        self.weight_sharing = weight_sharing
+        if weight_sharing:
+            self.layer = BiDirCMLayer(d_model, n_heads, n_levels, n_points)
+        else:
+            self.layer = nn.ModuleList(
+                BiDirCMLayer(d_model, n_heads, n_levels, n_points) for _ in range(n_layers)
+            )
+
+    def forward(
+        self,
+        txt_tokens: torch.Tensor,
+        feats: list[torch.Tensor],
+        spatial_shapes: torch.Tensor,
+        level_start_index: torch.Tensor,
+        reference_points: torch.Tensor,
+        vis_tokens: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if vis_tokens is None:
+            vis_tokens = torch.cat([feat.flatten(2).transpose(1, 2) for feat in feats], dim=1)
+
+        txt_out, vis_out, attn = txt_tokens, vis_tokens, None
+        for idx in range(self.n_layers):
+            layer = self.layer if self.weight_sharing else self.layer[idx]
+            txt_out, vis_out, attn = layer(
+                txt_out,
+                vis_out,
+                feats,
+                spatial_shapes,
+                level_start_index,
+                reference_points,
+            )
+        return txt_out, vis_out, attn
+
+
+def attention_alignment_loss(
+    attn_weights: torch.Tensor, gt_mask: torch.Tensor, reduction: str = "mean"
+) -> torch.Tensor:
+    if gt_mask.dim() == 1:
+        gt_mask = gt_mask.unsqueeze(0)
+    if attn_weights.dim() != 3:
+        raise ValueError("Expected attention weights with shape [B, N, L].")
+
+    if gt_mask.dim() == 2:
+        gt_mask = gt_mask.unsqueeze(1)
+    gt_mask = gt_mask.to(attn_weights.dtype)
+
+    probs = attn_weights.mean(dim=2).unsqueeze(1).clamp(1e-6, 1 - 1e-6)
+    if gt_mask.shape[-1] != probs.shape[-1]:
+        raise ValueError("Ground truth mask and attention size mismatch.")
+    return F.binary_cross_entropy(probs, gt_mask, reduction=reduction)
+


### PR DESCRIPTION
## Summary
- add the ID-MSCMA module with FiLMLite modulation and attention-alignment loss utilities
- wire the new cross-modal block into the LQVG model and expose generated features and attention weights
- hook the attention-alignment loss into the criterion alongside the existing DSGL pathway

## Testing
- python -m compileall models/id_mscma.py models/LQVG.py models/criterion.py

------
https://chatgpt.com/codex/tasks/task_e_68cb9ea157fc8332980b1f9ba019356e