### PR TITLE
Add configurable LoRA support to LQVG model

### DIFF
--- a/main.py
+++ b/main.py
@@ -214,6 +214,16 @@ def main(args):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser('ReferFormer pretrain training and evaluation script', parents=[opts.get_args_parser()])
+    parser.add_argument('--lora', action='store_true')
+    parser.add_argument('--lora_preset', type=str, default='balanced', choices=['light', 'balanced', 'max'])
+    parser.add_argument('--lora_text', action='store_true')
+    parser.add_argument('--lora_fusion', action='store_true')
+    parser.add_argument('--lora_decoder', action='store_true')
+    parser.add_argument('--lora_encoder', action='store_true')
+    parser.add_argument('--lora_input_proj', action='store_true')
+    parser.add_argument('--lora_rank', type=int, default=8)
+    parser.add_argument('--lora_alpha', type=int, default=32)
+    parser.add_argument('--lora_dropout', type=float, default=0.05)
     args = parser.parse_args()
     if args.output_dir:
         Path(args.output_dir).mkdir(parents=True, exist_ok=True)

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,5 +1,101 @@
 from .LQVG import build
 
+from .lora_utils import (
+    apply_conv_lora_1x1,
+    apply_lora_linear,
+    freeze_all_but_lora_and_heads,
+    report_trainable,
+)
+
+TEXT_LORA_PATTERNS = [
+    r"^text_encoder\.encoder\.layer\.\d+\.attention\.self\.(query|key|value)$",
+    r"^text_encoder\.encoder\.layer\.\d+\.attention\.output\.dense$",
+    r"^text_encoder\.encoder\.layer\.\d+\.intermediate\.dense$",
+    r"^text_encoder\.encoder\.layer\.\d+\.output\.dense$",
+    r"^text_encoder\.pooler\.dense$",
+]
+
+FUSION_LORA_PATTERNS = [
+    r"^fusion_module\.multihead_attn\.out_proj$",
+    r"^fusion_module_text\.multihead_attn\.out_proj$",
+]
+
+DECODER_LORA_PATTERNS = [
+    r"^transformer\.decoder\.layers\.\d+\.self_attn\.out_proj$",
+    r"^transformer\.decoder\.layers\.\d+\.linear1$",
+    r"^transformer\.decoder\.layers\.\d+\.linear2$",
+]
+
+DECODER_DEFORM_PATTERNS = [
+    r"^transformer\.decoder\.layers\.\d+\.cross_attn\.(sampling_offsets|attention_weights|value_proj|output_proj)$",
+]
+
+ENCODER_LORA_PATTERNS = [
+    r"^transformer\.encoder\.layers\.\d+\.linear1$",
+    r"^transformer\.encoder\.layers\.\d+\.linear2$",
+]
+
+ENCODER_DEFORM_PATTERNS = [
+    r"^transformer\.encoder\.layers\.\d+\.self_attn\.(sampling_offsets|attention_weights|value_proj|output_proj)$",
+]
+
+INPUT_PROJ_PATTERNS = [
+    r"^input_proj\.\d+\.0$",
+]
+
+
+def _resolve_lora_flags(args):
+    preset = getattr(args, "lora_preset", "balanced")
+    flags = {
+        "text": getattr(args, "lora_text", False),
+        "fusion": getattr(args, "lora_fusion", False),
+        "decoder": getattr(args, "lora_decoder", False),
+        "encoder": getattr(args, "lora_encoder", False),
+        "input_proj": getattr(args, "lora_input_proj", False),
+    }
+    if not any(flags.values()):
+        if preset == "light":
+            flags["decoder"] = True
+        elif preset == "balanced":
+            flags.update({"text": True, "fusion": True, "decoder": True})
+        elif preset == "max":
+            for key in flags:
+                flags[key] = True
+    return flags
+
 
 def build_model(args):
-    return build(args)
+    model, criterion, postprocessors = build(args)
+
+    if not getattr(args, "lora", False):
+        return model, criterion, postprocessors
+
+    rank = getattr(args, "lora_rank", 8)
+    alpha = getattr(args, "lora_alpha", 32)
+    dropout = getattr(args, "lora_dropout", 0.05)
+
+    flags = _resolve_lora_flags(args)
+
+    if flags.get("text"):
+        apply_lora_linear(model, TEXT_LORA_PATTERNS, r=rank, alpha=alpha, dropout=dropout)
+
+    if flags.get("fusion"):
+        apply_lora_linear(model, FUSION_LORA_PATTERNS, r=rank, alpha=alpha, dropout=dropout)
+
+    if flags.get("decoder"):
+        apply_lora_linear(model, DECODER_LORA_PATTERNS, r=rank, alpha=alpha, dropout=dropout)
+        apply_lora_linear(model, DECODER_DEFORM_PATTERNS, r=rank, alpha=alpha, dropout=dropout)
+
+    if flags.get("encoder"):
+        apply_lora_linear(model, ENCODER_LORA_PATTERNS, r=rank, alpha=alpha, dropout=dropout)
+        apply_lora_linear(model, ENCODER_DEFORM_PATTERNS, r=rank, alpha=alpha, dropout=dropout)
+
+    if flags.get("input_proj"):
+        conv_rank = max(4, rank // 2)
+        apply_conv_lora_1x1(model, INPUT_PROJ_PATTERNS, r=conv_rank, alpha=alpha)
+
+    keep_keywords = ["class_embed", "bbox_embed", "query_embed", "reference_points"]
+    freeze_all_but_lora_and_heads(model, keep_keywords=keep_keywords)
+    report_trainable(model)
+
+    return model, criterion, postprocessors

--- a/models/lora_utils.py
+++ b/models/lora_utils.py
@@ -1,0 +1,198 @@
+import re
+from typing import Iterable, List, Sequence
+
+import torch
+import torch.nn as nn
+
+try:  # pragma: no cover - optional dependency
+    from peft import LoraConfig, TaskType, get_peft_model
+    _HAS_PEFT = True
+except Exception:  # pragma: no cover - optional dependency
+    _HAS_PEFT = False
+
+
+class LoRALinear(nn.Module):
+    def __init__(self, linear: nn.Linear, r: int = 8, alpha: int = 32, dropout: float = 0.0):
+        super().__init__()
+        if not isinstance(linear, nn.Linear):
+            raise TypeError("LoRALinear expects an nn.Linear module")
+        self.in_features = linear.in_features
+        self.out_features = linear.out_features
+        self.r = r
+        self.alpha = alpha
+        self.dropout = nn.Dropout(dropout) if dropout > 0 else nn.Identity()
+        self.weight = linear.weight
+        self.bias = linear.bias
+        if self.weight is not None:
+            self.weight.requires_grad_(False)
+        if self.bias is not None:
+            self.bias.requires_grad_(False)
+        self.A = nn.Linear(self.in_features, r, bias=False)
+        self.B = nn.Linear(r, self.out_features, bias=False)
+        nn.init.kaiming_uniform_(self.A.weight, a=5 ** 0.5)
+        nn.init.zeros_(self.B.weight)
+        self.scaling = self.alpha / max(1, self.r)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        base = nn.functional.linear(x, self.weight, self.bias)
+        lora = self.B(self.A(self.dropout(x))) * self.scaling
+        return base + lora
+
+
+class ConvLoRA1x1(nn.Module):
+    def __init__(self, conv1x1: nn.Conv2d, r: int = 4, alpha: int = 32):
+        super().__init__()
+        if not isinstance(conv1x1, nn.Conv2d) or conv1x1.kernel_size != (1, 1):
+            raise TypeError("ConvLoRA1x1 expects a 1x1 nn.Conv2d module")
+        self.conv = conv1x1
+        self.conv.requires_grad_(False)
+        in_channels = conv1x1.in_channels
+        out_channels = conv1x1.out_channels
+        self.A = nn.Conv2d(in_channels, r, kernel_size=1, bias=False)
+        self.B = nn.Conv2d(r, out_channels, kernel_size=1, bias=False)
+        nn.init.kaiming_uniform_(self.A.weight, a=5 ** 0.5)
+        nn.init.zeros_(self.B.weight)
+        self.scaling = alpha / max(1, r)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.conv(x) + self.B(self.A(x)) * self.scaling
+
+
+def _match_any(name: str, regex_list: Sequence[str]) -> bool:
+    return any(re.match(pattern, name) for pattern in regex_list)
+
+
+def _get_parent_module(model: nn.Module, name: str):
+    if not name:
+        return None, ''
+    parts = name.split('.')
+    module = model
+    for part in parts[:-1]:
+        if part.isdigit() and isinstance(module, (nn.Sequential, nn.ModuleList, list)):
+            module = module[int(part)]
+        else:
+            module = getattr(module, part)
+    return module, parts[-1]
+
+
+def _get_module(model: nn.Module, name: str) -> nn.Module:
+    if not name:
+        return model
+    parts = name.split('.')
+    module = model
+    for part in parts:
+        if part.isdigit() and isinstance(module, (nn.Sequential, nn.ModuleList, list)):
+            module = module[int(part)]
+        else:
+            module = getattr(module, part)
+    return module
+
+
+def _set_module(model: nn.Module, name: str, new_module: nn.Module) -> None:
+    parent, attr = _get_parent_module(model, name)
+    if parent is None:
+        raise ValueError(f"Cannot set module for root name '{name}'")
+    if attr.isdigit() and isinstance(parent, (nn.Sequential, nn.ModuleList, list)):
+        parent[int(attr)] = new_module
+    else:
+        setattr(parent, attr, new_module)
+
+
+def _collect_named_modules(model: nn.Module) -> List[tuple]:
+    return list(model.named_modules())
+
+
+def apply_lora_linear(model: nn.Module, regex_list: Sequence[str], r: int = 8, alpha: int = 32, dropout: float = 0.05) -> None:
+    if not regex_list:
+        return
+    replaced_set = set()
+    named_modules = _collect_named_modules(model)
+
+    if _HAS_PEFT:
+        target_modules: List[str] = []
+        for name, module in named_modules:
+            if isinstance(module, nn.Linear) and _match_any(name, regex_list):
+                target_modules.append(name)
+        if target_modules:
+            peft_config = LoraConfig(
+                task_type=TaskType.FEATURE_EXTRACTION,
+                r=r,
+                lora_alpha=alpha,
+                lora_dropout=dropout,
+                target_modules=target_modules,
+            )
+            get_peft_model(model, peft_config)
+            replaced_set.update(target_modules)
+
+    # Manual fallback or additional wrapping for fine-grained control
+    for name, module in named_modules:
+        if not isinstance(module, nn.Linear) or not _match_any(name, regex_list):
+            continue
+        current_module = _get_module(model, name)
+        if not isinstance(current_module, nn.Linear):
+            continue
+        lora_module = LoRALinear(current_module, r=r, alpha=alpha, dropout=dropout)
+        _set_module(model, name, lora_module)
+        replaced_set.add(name)
+
+    replaced = sorted(replaced_set)
+    print(f"[LoRA] Linear wrapped: {len(replaced)}")
+    for entry in replaced[:10]:
+        print(f"  - {entry}")
+    if len(replaced) > 10:
+        print("  ...")
+
+
+def apply_conv_lora_1x1(model: nn.Module, regex_list: Sequence[str], r: int = 4, alpha: int = 32) -> None:
+    if not regex_list:
+        return
+    replaced_set = set()
+    for name, module in _collect_named_modules(model):
+        if isinstance(module, nn.Conv2d) and module.kernel_size == (1, 1) and _match_any(name, regex_list):
+            lora_module = ConvLoRA1x1(module, r=r, alpha=alpha)
+            _set_module(model, name, lora_module)
+            replaced_set.add(name)
+    replaced = sorted(replaced_set)
+    print(f"[LoRA] Conv1x1 wrapped: {len(replaced)}")
+    for entry in replaced[:10]:
+        print(f"  - {entry}")
+    if len(replaced) > 10:
+        print("  ...")
+
+
+def freeze_all_but_lora_and_heads(model: nn.Module, keep_keywords: Iterable[str] = ()):  # noqa: D401
+    for param in model.parameters():
+        param.requires_grad_(False)
+
+    for module in model.modules():
+        if isinstance(module, LoRALinear):
+            for name, param in module.named_parameters():
+                if name.startswith('A') or name.startswith('B'):
+                    param.requires_grad_(True)
+        elif isinstance(module, ConvLoRA1x1):
+            for name, param in module.named_parameters():
+                if name.startswith('A') or name.startswith('B'):
+                    param.requires_grad_(True)
+
+    keep_keywords = tuple(keep_keywords or ())
+    if keep_keywords:
+        for name, param in model.named_parameters():
+            if any(keyword in name for keyword in keep_keywords):
+                param.requires_grad_(True)
+
+
+def report_trainable(model: nn.Module) -> None:
+    total = sum(param.numel() for param in model.parameters())
+    trainable = sum(param.numel() for param in model.parameters() if param.requires_grad)
+    pct = 100.0 * trainable / max(1, total)
+    print(f"[LoRA] Trainable params: {trainable}/{total} ({pct:.2f}%)")
+
+
+__all__ = [
+    'LoRALinear',
+    'ConvLoRA1x1',
+    'apply_lora_linear',
+    'apply_conv_lora_1x1',
+    'freeze_all_but_lora_and_heads',
+    'report_trainable',
+]


### PR DESCRIPTION
## Summary
- add training flags to enable and configure LoRA from the CLI
- introduce reusable utilities to wrap linear and 1×1 convolution layers with LoRA adapters and manage parameter freezing
- integrate the LoRA helpers into model construction, including presets, selective freezing, and trainable parameter reporting

## Testing
- python -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68de0dd5ee808332857d9928fa4bb3a4