### PR TITLE
Integrate MMCA adapters into LQVG

### DIFF
--- a/models/LQVG.py
+++ b/models/LQVG.py
@@ -14,6 +14,7 @@ from .position_encoding import PositionEmbeddingSine1D
 from .backbone import build_backbone
 from .deformable_transformer import build_deforamble_transformer
 from .segmentation import VisionLanguageFusionModule
+from .text_guide_linear import MM_adaption_conv_2d, MM_adaption_linear
 from .matcher import build_matcher
 from .criterion import SetCriterion
 from .postprocessors import build_postprocessors
@@ -122,6 +123,37 @@ class LQVG(nn.Module):
         self.text_pos = PositionEmbeddingSine1D(hidden_dim, normalize=True)
         self.poolout_module = RobertaPoolout(d_model=hidden_dim)
 
+        self.use_mmca_conv = True
+        self.use_mmca_lin = True
+
+        last3_channels = backbone.num_channels[-3:]
+        self.mmca_conv = nn.ModuleList([
+            MM_adaption_conv_2d(
+                d_model=hidden_dim,
+                d_model_visual=last3_channels[i],
+                down_rate=4,
+                d_text=hidden_dim,
+            )
+            for i in range(len(last3_channels))
+        ])
+
+        self.mmca_lin_vis = nn.ModuleList([
+            MM_adaption_linear(
+                d_model=hidden_dim,
+                d_model_visual=hidden_dim,
+                down_rate=4,
+                d_text=hidden_dim,
+            )
+            for _ in range(len(last3_channels))
+        ])
+
+        self.mmca_lin_txt = MM_adaption_linear(
+            d_model=hidden_dim,
+            d_model_visual=hidden_dim,
+            down_rate=4,
+            d_text=hidden_dim,
+        )
+
     def forward(self, samples: NestedTensor, captions, targets):
 
         # Backbone
@@ -156,6 +188,7 @@ class LQVG(nn.Module):
 
         text_pos = self.text_pos(text_features).permute(2, 0, 1)  # [length, batch_size, c]
         text_word_features, text_word_masks = text_features.decompose()
+        text_word_features_raw = text_word_features
 
         text_word_features = text_word_features.permute(1, 0, 2)  # [length, batch_size, c]
         text_word_initial_features = text_word_features
@@ -163,6 +196,8 @@ class LQVG(nn.Module):
         # Follow Deformable-DETR, we use the last three stages outputs from backbone
         for l, (feat, pos_l) in enumerate(zip(features[-3:], pos[-3:])):
             src, mask = feat.decompose()
+            if self.use_mmca_conv:
+                src = self.mmca_conv[l](src, text_word_features_raw)
             src_proj_l = self.input_proj[l](src)
             n, c, h, w = src_proj_l.shape
 
@@ -170,11 +205,23 @@ class LQVG(nn.Module):
             src_proj_l = rearrange(src_proj_l, '(b t) c h w -> (t h w) b c', b=b, t=t)
             mask = rearrange(mask, '(b t) h w -> b (t h w)', b=b, t=t)
             pos_l = rearrange(pos_l, '(b t) c h w -> (t h w) b c', b=b, t=t)
+
+            if self.use_mmca_lin:
+                flat_vis_bf = rearrange(src_proj_l, 'l b c -> b l c')
+                flat_vis_bf = self.mmca_lin_vis[l](flat_vis_bf, text_word_features_raw)
+                src_proj_l = rearrange(flat_vis_bf, 'b l c -> l b c')
+
+                txt_bf = rearrange(text_word_features, 'l b c -> b l c')
+                txt_bf = self.mmca_lin_txt(txt_bf, flat_vis_bf)
+                text_word_features = rearrange(txt_bf, 'b l c -> l b c')
+
             text_word_features = self.fusion_module_text(tgt=text_word_features,
                                                          memory=src_proj_l,
                                                          memory_key_padding_mask=mask,
                                                          pos=pos_l,
                                                          query_pos=None)
+
+            text_word_features_raw = rearrange(text_word_features, 'l b c -> b l c')
 
             src_proj_l = self.fusion_module(tgt=src_proj_l,
                                             memory=text_word_initial_features,

--- a/models/text_guide_linear.py
+++ b/models/text_guide_linear.py
@@ -1,0 +1,93 @@
+import torch
+import torch.nn as nn
+
+
+class GF_block(nn.Module):
+    def __init__(self, d_model=256, d_model_visual=256, d_text=256, isTR=True):
+        """
+        - isTR=True: x là token [B, L_v, C_v]
+        - isTR=False: x là fmap [B, C_v, H, W]
+        """
+        super().__init__()
+        self.isTR = isTR
+        if isTR:
+            self.visual_down = nn.Linear(d_model_visual, d_model, bias=False)
+        else:
+            self.visual_down = nn.Conv2d(d_model_visual, d_model, kernel_size=1, bias=False)
+        self.text_down = nn.Linear(d_text, d_model, bias=False)
+        self.mm = nn.Sequential(
+            nn.Linear(d_model, d_model // 4),
+            nn.ReLU(),
+            nn.Linear(d_model // 4, d_model),
+        )
+
+    def forward(self, x, word_feat_embed):
+        # word_feat_embed: [B, L_t, d_text] hoặc [B, 1, d_text]
+        word = self.text_down(word_feat_embed)          # [B, L_t, d_model]
+        word = word.mean(dim=1, keepdim=True)           # [B, 1, d_model]
+
+        if self.isTR:
+            # x: [B, L_v, C_v] -> [B, L_v, d_model]
+            x = self.visual_down(x)
+            x_mean = x.mean(dim=1, keepdim=True)        # [B, 1, d_model]
+        else:
+            # x: [B, C_v, H, W] -> [B, d_model, H, W]
+            x = self.visual_down(x)
+            x_mean = x.mean(dim=(2, 3), keepdim=True)   # [B, d_model, 1, 1]
+            x_mean = x_mean.flatten(2).transpose(1, 2)  # [B, 1, d_model]
+
+        lam = torch.sigmoid(self.mm(x_mean))            # [B, 1, d_model]
+        mm_embed = word + lam * x_mean                  # [B, 1, d_model]
+        return mm_embed
+
+
+class MM_adaption_linear(nn.Module):
+    def __init__(self, d_model=256, d_model_visual=256, down_rate=4, d_text=256):
+        """
+        Điều biến token-level (batch-first):
+          x: [B, L, C_v], word_feat_embed: [B, L_t, d_text]
+        """
+        super().__init__()
+        mid = max(1, d_model // down_rate)
+        self.down = nn.Linear(d_model_visual, mid, bias=False)
+        self.fuse = GF_block(d_model=d_model, d_model_visual=d_model_visual, d_text=d_text, isTR=True)
+        self.gen_scale = nn.Linear(d_model, mid, bias=True)
+        self.up = nn.Linear(mid, d_model_visual, bias=False)
+        # near-identity init (Δ≈0)
+        nn.init.zeros_(self.gen_scale.weight)
+        nn.init.zeros_(self.gen_scale.bias)
+
+    def forward(self, x, word_feat_embed):
+        # x: [B, L, C_v]
+        x_mid = self.down(x)                            # [B, L, mid]
+        cond = self.fuse(x, word_feat_embed)            # [B, 1, d_model]
+        scale = self.gen_scale(cond)                    # [B, 1, mid]
+        x_mid = x_mid * scale                           # broadcast theo L
+        x_delta = self.up(x_mid)                        # [B, L, C_v]
+        return x + x_delta                              # residual
+
+
+class MM_adaption_conv_2d(nn.Module):
+    def __init__(self, d_model=256, d_model_visual=256, down_rate=4, d_text=256):
+        """
+        Điều biến feature map trước input_proj:
+          x: [B, C_v, H, W], word_feat_embed: [B, L_t, d_text]
+        """
+        super().__init__()
+        mid = max(1, d_model // down_rate)
+        self.down = nn.Conv2d(d_model_visual, mid, kernel_size=3, stride=1, padding=1, bias=False)
+        self.fuse = GF_block(d_model=d_model, d_model_visual=d_model_visual, d_text=d_text, isTR=False)
+        self.gen_scale = nn.Linear(d_model, mid, bias=True)
+        self.up = nn.Conv2d(mid, d_model_visual, kernel_size=1, bias=False)
+        # near-identity init
+        nn.init.zeros_(self.gen_scale.weight)
+        nn.init.zeros_(self.gen_scale.bias)
+
+    def forward(self, x, word_feat_embed):
+        B, _, H, W = x.shape
+        x_mid = self.down(x)                            # [B, mid, H, W]
+        cond = self.fuse(x, word_feat_embed)            # [B, 1, d_model]
+        scale = self.gen_scale(cond).transpose(1, 2)    # [B, mid, 1]
+        x_mid = x_mid * scale[..., None]                # [B, mid, H, W]
+        x_delta = self.up(x_mid)                        # [B, C_v, H, W]
+        return x + x_delta                              # residual


### PR DESCRIPTION
## Summary
- add modular MMCA adapters for feature-map and token modulation
- integrate the adapters into LQVG with runtime toggles before fusion

## Testing
- python -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68de8dd26b68833295086ba126b181b2