### PR TITLE
Refine MMCA placement and expand LoRA coverage

### DIFF
--- a/models/LQVG.py
+++ b/models/LQVG.py
@@ -14,6 +14,7 @@ from .position_encoding import PositionEmbeddingSine1D
 from .backbone import build_backbone
 from .deformable_transformer import build_deforamble_transformer
 from .segmentation import VisionLanguageFusionModule
+from .text_guide_linear import MM_adaption_conv_2d, MM_adaption_linear
 from .matcher import build_matcher
 from .criterion import SetCriterion
 from .postprocessors import build_postprocessors
@@ -122,6 +123,32 @@ class LQVG(nn.Module):
         self.text_pos = PositionEmbeddingSine1D(hidden_dim, normalize=True)
         self.poolout_module = RobertaPoolout(d_model=hidden_dim)
 
+        self.use_mmca_conv = True
+        self.use_mmca_lin = True
+
+        last3_channels = backbone.num_channels[-3:]
+        self.mmca_conv = nn.ModuleList([
+            MM_adaption_conv_2d(
+                d_model=hidden_dim,
+                d_model_visual=hidden_dim,
+                down_rate=4,
+                d_text=hidden_dim,
+            )
+            for _ in range(len(last3_channels))
+        ])
+
+        self.mmca_lin_vis = nn.ModuleList([
+            MM_adaption_linear(
+                d_model=hidden_dim,
+                d_model_visual=hidden_dim,
+                down_rate=4,
+                d_text=hidden_dim,
+            )
+            for _ in range(len(last3_channels))
+        ])
+
+        self.mmca_lin_txt = None
+
     def forward(self, samples: NestedTensor, captions, targets):
 
         # Backbone
@@ -156,6 +183,11 @@ class LQVG(nn.Module):
 
         text_pos = self.text_pos(text_features).permute(2, 0, 1)  # [length, batch_size, c]
         text_word_features, text_word_masks = text_features.decompose()
+        text_word_features_raw = text_word_features.clone()
+        if t > 1:
+            text_word_features_raw_conv = text_word_features_raw.repeat_interleave(t, dim=0)
+        else:
+            text_word_features_raw_conv = text_word_features_raw
 
         text_word_features = text_word_features.permute(1, 0, 2)  # [length, batch_size, c]
         text_word_initial_features = text_word_features
@@ -164,17 +196,26 @@ class LQVG(nn.Module):
         for l, (feat, pos_l) in enumerate(zip(features[-3:], pos[-3:])):
             src, mask = feat.decompose()
             src_proj_l = self.input_proj[l](src)
+            if self.use_mmca_conv:
+                src_proj_l = self.mmca_conv[l](src_proj_l, text_word_features_raw_conv)
             n, c, h, w = src_proj_l.shape
 
             # vision language early-fusion
             src_proj_l = rearrange(src_proj_l, '(b t) c h w -> (t h w) b c', b=b, t=t)
             mask = rearrange(mask, '(b t) h w -> b (t h w)', b=b, t=t)
             pos_l = rearrange(pos_l, '(b t) c h w -> (t h w) b c', b=b, t=t)
+
+            if self.use_mmca_lin:
+                flat_vis_bf = rearrange(src_proj_l, 'l b c -> b l c')
+                flat_vis_bf = self.mmca_lin_vis[l](flat_vis_bf, text_word_features_raw)
+                src_proj_l = rearrange(flat_vis_bf, 'b l c -> l b c')
+
             text_word_features = self.fusion_module_text(tgt=text_word_features,
                                                          memory=src_proj_l,
                                                          memory_key_padding_mask=mask,
                                                          pos=pos_l,
                                                          query_pos=None)
+
 
             src_proj_l = self.fusion_module(tgt=src_proj_l,
                                             memory=text_word_initial_features,

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -16,12 +16,12 @@ TEXT_LORA_PATTERNS = [
 ]
 
 FUSION_LORA_PATTERNS = [
-    r"^fusion_module\.multihead_attn\.out_proj$",
-    r"^fusion_module_text\.multihead_attn\.out_proj$",
+    r"^fusion_module\.multihead_attn$",
+    r"^fusion_module_text\.multihead_attn$",
 ]
 
 DECODER_LORA_PATTERNS = [
-    r"^transformer\.decoder\.layers\.\d+\.self_attn\.out_proj$",
+    r"^transformer\.decoder\.layers\.\d+\.self_attn$",
     r"^transformer\.decoder\.layers\.\d+\.linear1$",
     r"^transformer\.decoder\.layers\.\d+\.linear2$",
 ]

--- a/models/lora_utils.py
+++ b/models/lora_utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, List, Sequence
+from typing import Iterable, List, Optional, Sequence, Tuple
 
 import torch
 import torch.nn as nn
@@ -58,6 +58,133 @@ class ConvLoRA1x1(nn.Module):
         return self.conv(x) + self.B(self.A(x)) * self.scaling
 
 
+class LoRAMultiheadAttention(nn.Module):
+    def __init__(self, attn: nn.MultiheadAttention, r: int = 8, alpha: int = 32, dropout: float = 0.05):
+        super().__init__()
+        if attn.batch_first:
+            raise ValueError("LoRAMultiheadAttention does not currently support batch_first=True")
+        if attn.bias_k is not None or attn.bias_v is not None:
+            raise ValueError("LoRAMultiheadAttention does not support bias_k or bias_v")
+
+        self.embed_dim = attn.embed_dim
+        self.num_heads = attn.num_heads
+        if self.embed_dim % self.num_heads != 0:
+            raise ValueError("embed_dim must be divisible by num_heads")
+        self.head_dim = self.embed_dim // self.num_heads
+        self.dropout_p = attn.dropout
+
+        in_proj_bias = attn.in_proj_bias is not None
+        weight = attn.in_proj_weight.detach()
+        bias = attn.in_proj_bias.detach() if in_proj_bias else None
+
+        q_linear = nn.Linear(self.embed_dim, self.embed_dim, bias=in_proj_bias)
+        k_linear = nn.Linear(self.embed_dim, self.embed_dim, bias=in_proj_bias)
+        v_linear = nn.Linear(self.embed_dim, self.embed_dim, bias=in_proj_bias)
+
+        q_linear.weight.data.copy_(weight[:self.embed_dim])
+        k_linear.weight.data.copy_(weight[self.embed_dim:2 * self.embed_dim])
+        v_linear.weight.data.copy_(weight[2 * self.embed_dim:])
+        if in_proj_bias:
+            q_linear.bias.data.copy_(bias[:self.embed_dim])
+            k_linear.bias.data.copy_(bias[self.embed_dim:2 * self.embed_dim])
+            v_linear.bias.data.copy_(bias[2 * self.embed_dim:])
+
+        out_linear = nn.Linear(self.embed_dim, self.embed_dim, bias=attn.out_proj.bias is not None)
+        out_linear.weight.data.copy_(attn.out_proj.weight.detach())
+        if attn.out_proj.bias is not None:
+            out_linear.bias.data.copy_(attn.out_proj.bias.detach())
+
+        self.q_proj = LoRALinear(q_linear, r=r, alpha=alpha, dropout=dropout)
+        self.k_proj = LoRALinear(k_linear, r=r, alpha=alpha, dropout=dropout)
+        self.v_proj = LoRALinear(v_linear, r=r, alpha=alpha, dropout=dropout)
+        self.out_proj = LoRALinear(out_linear, r=r, alpha=alpha, dropout=dropout)
+
+    def _reshape(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (L, N, C) -> (N, heads, L, head_dim)
+        L, N, _ = x.shape
+        x = x.permute(1, 0, 2).contiguous().view(N, L, self.num_heads, self.head_dim)
+        return x.transpose(1, 2)
+
+    def _merge(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (N, heads, L, head_dim) -> (L, N, C)
+        N, _, L, _ = x.shape
+        x = x.transpose(1, 2).contiguous().view(N, L, self.embed_dim)
+        return x.permute(1, 0, 2)
+
+    def forward(self,
+                query: torch.Tensor,
+                key: Optional[torch.Tensor] = None,
+                value: Optional[torch.Tensor] = None,
+                key_padding_mask: Optional[torch.Tensor] = None,
+                need_weights: bool = False,
+                attn_mask: Optional[torch.Tensor] = None,
+                average_attn_weights: bool = True,
+                is_causal: bool = False,
+                **kwargs) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        del is_causal, kwargs  # Unused but kept for signature parity
+        if key is None:
+            key = query
+        if value is None:
+            value = key
+
+        q = self.q_proj(query)
+        k = self.k_proj(key)
+        v = self.v_proj(value)
+
+        scaling = float(self.head_dim) ** -0.5
+        q = self._reshape(q) * scaling
+        k = self._reshape(k)
+        v = self._reshape(v)
+
+        attn_logits = torch.matmul(q, k.transpose(-2, -1))
+
+        if attn_mask is not None:
+            if attn_mask.dtype == torch.bool:
+                if attn_mask.dim() == 2:
+                    bool_mask = attn_mask.unsqueeze(0).unsqueeze(0)
+                elif attn_mask.dim() == 3:
+                    bool_mask = attn_mask.unsqueeze(0)
+                else:
+                    raise ValueError("Unsupported boolean attn_mask dimension")
+                fill_value = torch.finfo(attn_logits.dtype).min
+                attn_logits = attn_logits.masked_fill(bool_mask, fill_value)
+            else:
+                if attn_mask.dim() == 2:
+                    attn_logits = attn_logits + attn_mask.unsqueeze(0).unsqueeze(0)
+                elif attn_mask.dim() == 3:
+                    attn_logits = attn_logits + attn_mask.unsqueeze(0)
+                else:
+                    raise ValueError("Unsupported attn_mask dimension")
+
+        mask = None
+        if key_padding_mask is not None:
+            mask = key_padding_mask.unsqueeze(1).unsqueeze(2)
+            fill_value = torch.finfo(attn_logits.dtype).min
+            attn_logits = attn_logits.masked_fill(mask, fill_value)
+
+        attn_logits = attn_logits - attn_logits.max(dim=-1, keepdim=True).values
+        attn_weights = torch.softmax(attn_logits, dim=-1)
+        if mask is not None:
+            attn_weights = attn_weights.masked_fill(mask, 0.0)
+            denom = attn_weights.sum(dim=-1, keepdim=True).clamp_min(torch.finfo(attn_weights.dtype).tiny)
+            attn_weights = attn_weights / denom
+        attn_weights = torch.dropout(attn_weights, self.dropout_p, self.training)
+
+        attn_output = torch.matmul(attn_weights, v)
+        attn_output = self._merge(attn_output)
+        attn_output = self.out_proj(attn_output)
+
+        if not need_weights:
+            return attn_output, None
+
+        if average_attn_weights:
+            attn_weights_out = attn_weights.mean(dim=1)
+        else:
+            attn_weights_out = attn_weights
+
+        return attn_output, attn_weights_out
+
+
 def _match_any(name: str, regex_list: Sequence[str]) -> bool:
     return any(re.match(pattern, name) for pattern in regex_list)
 
@@ -111,7 +238,7 @@ def apply_lora_linear(model: nn.Module, regex_list: Sequence[str], r: int = 8, a
     if _HAS_PEFT:
         target_modules: List[str] = []
         for name, module in named_modules:
-            if isinstance(module, nn.Linear) and _match_any(name, regex_list):
+            if isinstance(module, (nn.Linear, nn.MultiheadAttention)) and _match_any(name, regex_list):
                 target_modules.append(name)
         if target_modules:
             peft_config = LoraConfig(
@@ -126,9 +253,20 @@ def apply_lora_linear(model: nn.Module, regex_list: Sequence[str], r: int = 8, a
 
     # Manual fallback or additional wrapping for fine-grained control
     for name, module in named_modules:
-        if not isinstance(module, nn.Linear) or not _match_any(name, regex_list):
+        if not _match_any(name, regex_list):
             continue
+
         current_module = _get_module(model, name)
+
+        if isinstance(current_module, LoRALinear):
+            continue
+
+        if isinstance(current_module, nn.MultiheadAttention):
+            lora_module = LoRAMultiheadAttention(current_module, r=r, alpha=alpha, dropout=dropout)
+            _set_module(model, name, lora_module)
+            replaced_set.add(name)
+            continue
+
         if not isinstance(current_module, nn.Linear):
             continue
         lora_module = LoRALinear(current_module, r=r, alpha=alpha, dropout=dropout)

--- a/models/text_guide_linear.py
+++ b/models/text_guide_linear.py
@@ -1,0 +1,119 @@
+import torch
+import torch.nn as nn
+
+
+class GF_block(nn.Module):
+    def __init__(self, d_model=256, d_model_visual=256, d_text=256, isTR=True):
+        """
+        - isTR=True: x là token [B, L_v, C_v]
+        - isTR=False: x là fmap [B, C_v, H, W]
+        """
+        super().__init__()
+        self.isTR = isTR
+        if isTR:
+            self.visual_down = nn.Linear(d_model_visual, d_model, bias=False)
+        else:
+            self.visual_down = nn.Conv2d(d_model_visual, d_model, kernel_size=1, bias=False)
+        self.text_down = nn.Linear(d_text, d_model, bias=False)
+        self.mm = nn.Sequential(
+            nn.Linear(d_model, d_model // 4),
+            nn.ReLU(),
+            nn.Linear(d_model // 4, d_model),
+        )
+
+    def forward(self, x, word_feat_embed):
+        # word_feat_embed: [B, L_t, d_text] hoặc [B, 1, d_text]
+        word = self.text_down(word_feat_embed)          # [B, L_t, d_model]
+        word = word.mean(dim=1, keepdim=True)           # [B, 1, d_model]
+
+        if self.isTR:
+            # x: [B, L_v, C_v] -> [B, L_v, d_model]
+            x = self.visual_down(x)
+            x_mean = x.mean(dim=1, keepdim=True)        # [B, 1, d_model]
+        else:
+            # x: [B, C_v, H, W] -> [B, d_model, H, W]
+            x = self.visual_down(x)
+            x_mean = x.mean(dim=(2, 3), keepdim=True)   # [B, d_model, 1, 1]
+            x_mean = x_mean.flatten(2).transpose(1, 2)  # [B, 1, d_model]
+
+        lam = torch.sigmoid(self.mm(x_mean))            # [B, 1, d_model]
+        mm_embed = word + lam * x_mean                  # [B, 1, d_model]
+        return mm_embed
+
+
+class MM_adaption_linear(nn.Module):
+    def __init__(self, d_model=256, d_model_visual=256, down_rate=4, d_text=256):
+        """
+        Điều biến token-level (batch-first):
+          x: [B, L, C_v], word_feat_embed: [B, L_t, d_text]
+        """
+        super().__init__()
+        mid = max(1, d_model // down_rate)
+        self.down = nn.Linear(d_model_visual, mid, bias=False)
+        self.fuse = GF_block(d_model=d_model, d_model_visual=d_model_visual, d_text=d_text, isTR=True)
+        self.gen_scale = nn.Linear(d_model, mid, bias=True)
+        self.up = nn.Linear(mid, d_model_visual, bias=False)
+        # near-identity init (Δ≈0)
+        nn.init.zeros_(self.gen_scale.weight)
+        nn.init.zeros_(self.gen_scale.bias)
+
+    def forward(self, x, word_feat_embed):
+        # x: [B, L, C_v]
+        x_mid = self.down(x)                            # [B, L, mid]
+        cond = self.fuse(x, word_feat_embed)            # [B, 1, d_model]
+        scale = self.gen_scale(cond)                    # [B, 1, mid]
+        x_mid = x_mid * scale                           # broadcast theo L
+        x_delta = self.up(x_mid)                        # [B, L, C_v]
+        return x + x_delta                              # residual
+
+
+class MM_adaption_conv_2d(nn.Module):
+    def __init__(self, d_model=256, d_model_visual=256, down_rate=4, d_text=256):
+        """
+        Điều biến feature map sau input_proj:
+          x: [B, C_v, H, W], word_feat_embed: [B, L_t, d_text]
+        """
+        super().__init__()
+        self.d_model = d_model
+        self.d_text = d_text
+        self.down_rate = max(1, down_rate)
+        self.mid = max(1, d_model // self.down_rate)
+        self.gen_scale = nn.Linear(d_model, self.mid, bias=True)
+        # near-identity init
+        nn.init.zeros_(self.gen_scale.weight)
+        nn.init.zeros_(self.gen_scale.bias)
+
+        self._visual_channels = None
+        self.down: nn.Conv2d
+        self.up: nn.Conv2d
+        self.fuse: GF_block
+        self._set_visual_dim(d_model_visual)
+
+    def _set_visual_dim(self, channels: int) -> None:
+        channels = int(channels)
+        if self._visual_channels == channels:
+            return
+        self._visual_channels = channels
+        self.down = nn.Conv2d(channels, self.mid, kernel_size=3, stride=1, padding=1, bias=False)
+        self.up = nn.Conv2d(self.mid, channels, kernel_size=1, bias=False)
+        self.fuse = GF_block(d_model=self.d_model, d_model_visual=channels, d_text=self.d_text, isTR=False)
+
+    def forward(self, x, word_feat_embed):
+        if x.dim() != 4:
+            raise ValueError(f"MM_adaption_conv_2d expects 4D input, got {x.shape}")
+
+        visual_channels = x.shape[1]
+        if self._visual_channels != visual_channels:
+            # reconfigure to current channel count (e.g. when loading old checkpoints)
+            self._set_visual_dim(visual_channels)
+            self.down.to(device=x.device, dtype=x.dtype)
+            self.up.to(device=x.device, dtype=x.dtype)
+            self.fuse.to(device=x.device, dtype=x.dtype)
+
+        B, _, H, W = x.shape
+        x_mid = self.down(x)                            # [B, mid, H, W]
+        cond = self.fuse(x, word_feat_embed)            # [B, 1, d_model]
+        scale = self.gen_scale(cond).transpose(1, 2)    # [B, mid, 1]
+        x_mid = x_mid * scale[..., None]                # [B, mid, H, W]
+        x_delta = self.up(x_mid)                        # [B, self._visual_channels, H, W]
+        return x + x_delta                              # residual


### PR DESCRIPTION
## Summary
- move the MMCA adapters to operate on post-projection vision features while keeping their conditioning on raw text embeddings
- convert multihead attention modules to LoRA-aware wrappers and target them from the LoRA pattern configuration for fusion and decoder blocks
- extend LoRA application logic to recognize multihead attention modules alongside existing linear and deformable attention wrappers
- allow MMCA convolution adapters to reconfigure their channel expectations after checkpoint loads and ensure LoRA attention masking supports boolean masks
- ensure the LoRA multihead attention wrapper preserves PyTorch's transformer-style forward signature so existing call sites remain valid

## Testing
- python -m compileall models

------
https://chatgpt.com/codex/tasks/task_e_68de8dd26b68833295086ba126b181b2